### PR TITLE
Fix off centre 'Add Accent' button on Windows 11

### DIFF
--- a/Form1.Designer.vb
+++ b/Form1.Designer.vb
@@ -28,7 +28,8 @@ Partial Class Form1
         ' 
         ' Button1
         ' 
-        Button1.Location = New Point(6, 1)
+        Button1.Location = New Point((ClientSize.Width - Button1.Width) \ 2, 1)
+        Button1.Anchor = AnchorStyles.Top
         Button1.Name = "Button1"
         Button1.Size = New Size(170, 24)
         Button1.TabIndex = 0


### PR DESCRIPTION
Headlining button works fine on Windows 10 but is off centre on Windows 11 (as of 24H2). This PR fixes that.